### PR TITLE
Add zip code pattern for Canada (:ca).

### DIFF
--- a/lib/doggie_patterns.ex
+++ b/lib/doggie_patterns.ex
@@ -156,6 +156,7 @@ defmodule Doggie.Patterns do
       :be -> ~r/^\d{4}$/
       :bg -> ~r/^\d{4}$/
       :by -> ~r/^\d{6}$/
+      :ca -> ~r/^[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ ]?\d[ABCEGHJ-NPRSTV-Z]\d$/
       :ch -> ~r/^\d{4}$/
       :ck -> ~r/^\d{4}$/
       :cl -> ~r/^\d{3}-?\d{4}$/

--- a/test/doggie_patterns_test.exs
+++ b/test/doggie_patterns_test.exs
@@ -76,6 +76,22 @@ defmodule DoggieTest do
     assert Regex.match?(Doggie.Patterns.zip_code(:by), "123456")
     refute Regex.match?(Doggie.Patterns.zip_code(:by), "123456A")
 
+    assert Regex.match?(Doggie.Patterns.zip_code(:ca), "A1A 1A1")
+    assert Regex.match?(Doggie.Patterns.zip_code(:ca), "A1A1A1")
+    assert Regex.match?(Doggie.Patterns.zip_code(:ca), "H0H0H0")
+    assert Regex.match?(Doggie.Patterns.zip_code(:ca), "A1W1W1")
+    assert Regex.match?(Doggie.Patterns.zip_code(:ca), "A1Z1Z1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "A1A1A1A")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "1A1A1A")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "W1A1A1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "Z1A1A1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "D1D1D1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "F1F1F1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "I1I1I1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "O1O1O1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "Q1Q1Q1")
+    refute Regex.match?(Doggie.Patterns.zip_code(:ca), "U1U1U1")
+
     assert Regex.match?(Doggie.Patterns.zip_code(:ch), "1234")
     refute Regex.match?(Doggie.Patterns.zip_code(:ch), "1234A")
 


### PR DESCRIPTION
I'm from Canada and noticed Canadian zip codes weren't supported by Doggie, so I added them in this pull request.

I also created test cases for the edge cases (Canadian postal codes do not include the letters D, F, I, O, Q or U, and the first position also does not make use of the letters W or Z.)

Thank you, and happy Hacktoberfest!